### PR TITLE
Update module.json to fix installation error

### DIFF
--- a/module.json
+++ b/module.json
@@ -11,6 +11,6 @@
     ],
     "url": "https://github.com/hitcherland/FoundryVTT-Better-Hexagonal-Tiles",
     "manifest": "https://raw.githubusercontent.com/hitcherland/FoundryVTT-Better-Hexagonal-Tiles/master/module.json",
-    "download": "https://github.com/hitcherland/FoundryVTT-Better-Hexagonal-Tiles/archive/refs/tags/1.0.zip",
+    "download": "https://github.com/hitcherland/FoundryVTT-Better-Hexagonal-Tiles/archive/refs/tags/v1.0.zip",
     "readme": "https://raw.githubusercontent.com/hitcherland/FoundryVTT-Better-Hexagonal-Tiles/master/README.md"
 }


### PR DESCRIPTION
As addressed in #2 there is an error with the module.json that is causing FVTT to fail to download. I have created a PR which should fix the issue. Feel free to merge or replicate the change.